### PR TITLE
Add a command to help assist with gem set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ unzip path/to/downloaded/plugins.zip -d ~/.git_helper
 
 Now, the plugins will live in `~/.git_helper/plugins/*`. Add the following line to your `~/.bash_profile`:
 
-```
+```bash
 export PATH=/path/to/computer/home/.git_helper/plugins:$PATH
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To see what version of git_helper you're running, run:
 git-helper --version
 ```
 
-To help you create the `~/.git_helper/config.yml` file, run this command and allow the command to walk you through the prompts:
+To help you create the `~/.git_helper/config.yml` file and set up the plugins (see below), run this command and allow the command to walk you through the prompts:
 ```bash
 git-helper setup
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ To see what version of git_helper you're running, run:
 git-helper --version
 ```
 
+To help you create the `~/.git_helper/config.yml` file, run this command and allow the command to walk you through the prompts:
+```bash
+git-helper setup
+```
+
 ## Plugin Usage
 
 As an additional option, you can set each of the following commands to be a git plugin, meaning you can call them in a way that feels even more git-native:

--- a/bin/git-helper
+++ b/bin/git-helper
@@ -17,6 +17,13 @@ DOCUMENTATION
     see Git Helper's GitHub repo: https://github.com/emmahsax/git_helper
 """
 
+desc 'Sets up Git Helper configs at ~/.git_helper/*'
+command 'setup' do |c|
+  c.action do ||
+    GitHelper::Setup.new.execute
+  end
+end
+
 arg :old_owner
 arg :new_owner
 desc "Update a repository's remote URLs from an old GitHub owner to a new owner."

--- a/lib/git_helper/git_config_reader.rb
+++ b/lib/git_helper/git_config_reader.rb
@@ -8,12 +8,12 @@ module GitHelper
       config_file[:github_token]
     end
 
-    private def config_file
-      YAML.load_file(git_config_file_path)
+    def git_config_file_path
+      Dir.pwd.scan(/\A\/[\w]*\/[\w]*\//).first << git_config_file
     end
 
-    private def git_config_file_path
-      Dir.pwd.scan(/\A\/[\w]*\/[\w]*\//).first << git_config_file
+    private def config_file
+      YAML.load_file(git_config_file_path)
     end
 
     private def git_config_file

--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -3,35 +3,29 @@ module GitHelper
     def execute
       if config_file_exists?
         answer = highline.ask_yes_no("It looks like the #{config_file} file already exists. Do you wish to replace it? (y/n)")
-
-        unless answer
-          puts "\nExiting because you selected to not replace the #{config_file} file..."
-          exit
-        end
+        puts
+      else
+        answer = true
       end
 
-      create_or_update_config_file
+      if answer
+        create_or_update_config_file
+      end
 
-      # answer = highline.ask_yes_no("Do you wish to set up the Git Helper plugins? (y/n)")
-      # exit unless answer
+      answer = highline.ask_yes_no("Do you wish to set up the Git Helper plugins? (y/n)")
 
-      # if plugins_exist?
-      #   answer = highline.ask_yes_no("It looks like the plugins already exist. Do you wish to set up the Git Helper plugins? (y/n)")
-
-      #   unless answer
-      #     puts "\nExiting because you selected to not replace the #{config_file} file..."
-      #     exit
-      #   end
-      # end
-
-      # create_or_update_plugins
+      if answer
+        create_or_update_plugin_files
+        puts "\nNow add this line to your ~/.bash_profile:\n  export PATH=/path/to/computer/home/.git_helper/plugins:$PATH"
+        puts "\nDone!"
+      end
     end
 
     private def create_or_update_config_file
       contents = generate_file_contents
       puts "\nCreating or updating your #{config_file} file..."
       File.open(config_file, 'w') { |file| file.puts contents }
-      puts "\nDone!"
+      puts "\nDone!\n\n"
     end
 
     private def config_file_exists?
@@ -41,14 +35,18 @@ module GitHelper
     private def generate_file_contents
       file_contents = ''
 
-      if highline.ask_yes_no("\nDo you wish to set up GitHub credentials? (y/n)")
+      if highline.ask_yes_no("Do you wish to set up GitHub credentials? (y/n)")
         file_contents << ":github_user:  #{ask_question('GitHub username?')}\n"
-        file_contents << ":github_token: #{ask_question('GitHub personal access token? (Navigate to https://github.com/settings/tokens to create a new personal access token)')}\n"
+        file_contents << ":github_token: " \
+          "#{ask_question('GitHub personal access token? (Navigate to https://github.com/settings/tokens ' \
+          'to create a new personal access token)')}\n"
       end
 
       if highline.ask_yes_no("\nDo you wish to set up GitLab credentials? (y/n)")
         file_contents << ":gitlab_user:  #{ask_question('GitLab username?')}\n"
-        file_contents << ":gitlab_token: #{ask_question('GitLab personal access token? (Navigate to https://gitlab.com/-/profile/personal_access_tokens to create a new personal access token)')}\n"
+        file_contents << ":gitlab_token: " \
+          "#{ask_question('GitLab personal access token? (Navigate to https://gitlab.com/-/profile/personal_access_tokens ' \
+          'to create a new personal access token)')}\n"
       end
 
       file_contents.strip
@@ -71,6 +69,21 @@ module GitHelper
 
     private def config_file
       GitHelper::GitConfigReader.new.git_config_file_path
+    end
+
+    private def create_or_update_plugin_files
+      plugins_dir = "#{Dir.pwd.scan(/\A\/[\w]*\/[\w]*\//).first}/.git_helper/plugins"
+      plugins_url = 'https://api.github.com/repos/emmahsax/git_helper/contents/plugins'
+      header = 'Accept: application/vnd.github.v3.raw'
+
+      Dir.mkdir(plugins_dir) unless File.exists?(plugins_dir)
+
+      all_plugins = JSON.parse(`curl -s -H "#{header}" -L "#{plugins_url}"`)
+
+      all_plugins.each do |plugin|
+        plugin_content = `curl -s -H "#{header}" -L "#{plugins_url}/#{plugin['name']}"`
+        File.open("#{plugins_dir}/#{plugin['name']}", 'w') { |file| file.puts plugin_content }
+      end
     end
   end
 end

--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -1,0 +1,76 @@
+module GitHelper
+  class Setup
+    def execute
+      if config_file_exists?
+        answer = highline.ask_yes_no("It looks like the #{config_file} file already exists. Do you wish to replace it? (y/n)")
+
+        unless answer
+          puts "\nExiting because you selected to not replace the #{config_file} file..."
+          exit
+        end
+      end
+
+      create_or_update_config_file
+
+      # answer = highline.ask_yes_no("Do you wish to set up the Git Helper plugins? (y/n)")
+      # exit unless answer
+
+      # if plugins_exist?
+      #   answer = highline.ask_yes_no("It looks like the plugins already exist. Do you wish to set up the Git Helper plugins? (y/n)")
+
+      #   unless answer
+      #     puts "\nExiting because you selected to not replace the #{config_file} file..."
+      #     exit
+      #   end
+      # end
+
+      # create_or_update_plugins
+    end
+
+    private def create_or_update_config_file
+      contents = generate_file_contents
+      puts "\nCreating or updating your #{config_file} file..."
+      File.open(config_file, 'w') { |file| file.puts contents }
+      puts "\nDone!"
+    end
+
+    private def config_file_exists?
+      File.exists?(config_file)
+    end
+
+    private def generate_file_contents
+      file_contents = ''
+
+      if highline.ask_yes_no("\nDo you wish to set up GitHub credentials? (y/n)")
+        file_contents << ":github_user:  #{ask_question('GitHub username?')}\n"
+        file_contents << ":github_token: #{ask_question('GitHub personal access token? (Navigate to https://github.com/settings/tokens to create a new personal access token)')}\n"
+      end
+
+      if highline.ask_yes_no("\nDo you wish to set up GitLab credentials? (y/n)")
+        file_contents << ":gitlab_user:  #{ask_question('GitLab username?')}\n"
+        file_contents << ":gitlab_token: #{ask_question('GitLab personal access token? (Navigate to https://gitlab.com/-/profile/personal_access_tokens to create a new personal access token)')}\n"
+      end
+
+      file_contents.strip
+    end
+
+    private def ask_question(prompt)
+      answer = highline.ask("\n#{prompt}")
+
+      if answer.empty?
+        puts "\nThis question is required."
+        ask_question(prompt)
+      else
+        answer
+      end
+    end
+
+    private def highline
+      @highline ||= GitHelper::HighlineCli.new
+    end
+
+    private def config_file
+      GitHelper::GitConfigReader.new.git_config_file_path
+    end
+  end
+end

--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -8,9 +8,7 @@ module GitHelper
         answer = true
       end
 
-      if answer
-        create_or_update_config_file
-      end
+      create_or_update_config_file if answer
 
       answer = highline.ask_yes_no("Do you wish to set up the Git Helper plugins? (y/n)")
 

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,3 +1,3 @@
 module GitHelper
-  VERSION = '3.2.2'
+  VERSION = '3.3.0'
 end

--- a/spec/git_helper/code_request_spec.rb
+++ b/spec/git_helper/code_request_spec.rb
@@ -133,6 +133,7 @@ describe GitHelper::CodeRequest do
       end
     end
 
+    # Unfortunately this test sometimes fails... just rerun the tests if it does
     context 'when response is neither' do
       it 'should raise an error' do
         allow(highline_cli).to receive(:ask).and_return(Faker::Lorem.word)

--- a/spec/git_helper/setup_spec.rb
+++ b/spec/git_helper/setup_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+require 'git_helper'
+
+describe GitHelper::Setup do
+  let(:response) { double(:response, readline: true, to_s: Faker::Lorem.sentence) }
+  let(:highline_cli) { double(:highline_cli, ask: response, ask_yes_no: true) }
+
+  before do
+    allow(GitHelper::HighlineCli).to receive(:new).and_return(highline_cli)
+    allow(subject).to receive(:puts)
+  end
+
+  after do
+    GitHelper::Setup.instance_variable_set("@highline", nil)
+  end
+
+  describe '#execute' do
+    it 'should ask a question if the config file exists' do
+      allow(File).to receive(:exists?).and_return(true)
+      expect(highline_cli).to receive(:ask_yes_no).and_return(true)
+      allow(subject).to receive(:create_or_update_config_file).and_return(true)
+      subject.execute
+    end
+
+    it 'should call to create or update the config file' do
+      allow(File).to receive(:exists?).and_return(true)
+      allow(highline_cli).to receive(:ask_yes_no).and_return(true)
+      expect(subject).to receive(:create_or_update_config_file).and_return(true)
+      subject.execute
+    end
+
+    it 'should exit if the user opts not to continue' do
+      allow(File).to receive(:exists?).and_return(true)
+      allow(highline_cli).to receive(:ask_yes_no).and_return(false)
+      expect(subject).not_to receive(:create_or_update_config_file)
+      expect{ subject.execute }.to raise_error(SystemExit)
+    end
+  end
+
+  describe '#create_or_update_config_file' do
+    it 'should generate the file based on the answers to the questions' do
+      expect(subject).to receive(:generate_file_contents)
+      allow(File).to receive(:open).and_return(nil)
+      subject.send(:create_or_update_config_file)
+    end
+
+    it 'should open the file for writing' do
+      allow(subject).to receive(:generate_file_contents)
+      expect(File).to receive(:open).and_return(nil)
+      subject.send(:create_or_update_config_file)
+    end
+  end
+
+  describe '#config_file_exists?' do
+    it 'should return true if the file exists' do
+      allow(File).to receive(:exists?).and_return(true)
+      expect(subject.send(:config_file_exists?)).to eq(true)
+    end
+
+    it 'should return false if the file does not exist' do
+      allow(File).to receive(:exists?).and_return(false)
+      expect(subject.send(:config_file_exists?)).to eq(false)
+    end
+  end
+
+  describe '#ask_question' do
+    it 'should use highline to ask a question' do
+      expect(highline_cli).to receive(:ask).and_return(Faker::Lorem.word)
+      subject.send(:ask_question, Faker::Lorem.sentence)
+    end
+
+    it 'should recurse if the highline client gets an empty string' do
+      allow(highline_cli).to receive(:ask).and_return('', Faker::Lorem.word)
+      expect(subject).to receive(:ask_question).at_least(:twice).and_call_original
+      subject.send(:ask_question, Faker::Lorem.sentence)
+    end
+
+    it 'should return the answer if it is given' do
+      answer = Faker::Lorem.sentence
+      allow(highline_cli).to receive(:ask).and_return(answer)
+      expect(subject.send(:ask_question, Faker::Lorem.sentence)).to be(answer)
+    end
+  end
+
+  describe '#generate_file_contents' do
+    it 'should ask two yes/no questions' do
+      expect(highline_cli).to receive(:ask_yes_no).exactly(2).times.and_return(false)
+      subject.send(:generate_file_contents)
+    end
+
+    it 'should ask two additional questions for each time the user says yes' do
+      allow(highline_cli).to receive(:ask_yes_no).exactly(2).times.and_return(true, false)
+      expect(subject).to receive(:ask_question).exactly(2).times.and_return(Faker::Lorem.word)
+      subject.send(:generate_file_contents)
+    end
+
+    it 'should ask four additional questions for each time the user says yes' do
+      allow(highline_cli).to receive(:ask_yes_no).exactly(2).times.and_return(true)
+      expect(subject).to receive(:ask_question).exactly(4).times.and_return(Faker::Lorem.word)
+      subject.send(:generate_file_contents)
+    end
+
+    it 'should return a string no matter what' do
+      allow(highline_cli).to receive(:ask_yes_no).exactly(2).times.and_return(true)
+      allow(subject).to receive(:ask_question).exactly(4).times.and_return(Faker::Lorem.word)
+      expect(subject.send(:generate_file_contents)).to be_a(String)
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Add a new command `setup` which can be used to set up the initial `~/.git_helper/config.yml` config file and the plugins at `~/.git_helper/plugins*`. Call it like this:

```bash
git-helper setup
```

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.
