### PR TITLE
Authenticate with GitHub API

### DIFF
--- a/lib/git_helper/git_config_reader.rb
+++ b/lib/git_helper/git_config_reader.rb
@@ -4,8 +4,16 @@ module GitHelper
       config_file[:gitlab_token]
     end
 
+    def gitlab_user
+      config_file[:gitlab_user]
+    end
+
     def github_token
       config_file[:github_token]
+    end
+
+    def github_user
+      config_file[:github_user]
     end
 
     def git_config_file_path

--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -64,14 +64,6 @@ module GitHelper
       end
     end
 
-    private def highline
-      @highline ||= GitHelper::HighlineCli.new
-    end
-
-    private def config_file
-      git_config_reader.git_config_file_path
-    end
-
     private def create_or_update_plugin_files
       plugins_dir = "#{Dir.pwd.scan(/\A\/[\w]*\/[\w]*\//).first}/.git_helper/plugins"
       plugins_url = 'https://api.github.com/repos/emmahsax/git_helper/contents/plugins'
@@ -89,8 +81,16 @@ module GitHelper
       end
     end
 
+    private def config_file
+      git_config_reader.git_config_file_path
+    end
+
     private def git_config_reader
       @git_config_reader ||= GitHelper::GitConfigReader.new
+    end
+
+    private def highline
+      @highline ||= GitHelper::HighlineCli.new
     end
   end
 end

--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -10,7 +10,10 @@ module GitHelper
 
       create_or_update_config_file if answer
 
-      answer = highline.ask_yes_no("Do you wish to set up the Git Helper plugins? (y/n)")
+      answer = highline.ask_yes_no(
+        "Do you wish to set up the Git Helper plugins? (y/n) (This process will " \
+        "attempt to use your GitHub personal access token to authenticate)"
+      )
 
       if answer
         create_or_update_plugin_files
@@ -66,22 +69,28 @@ module GitHelper
     end
 
     private def config_file
-      GitHelper::GitConfigReader.new.git_config_file_path
+      git_config_reader.git_config_file_path
     end
 
     private def create_or_update_plugin_files
       plugins_dir = "#{Dir.pwd.scan(/\A\/[\w]*\/[\w]*\//).first}/.git_helper/plugins"
       plugins_url = 'https://api.github.com/repos/emmahsax/git_helper/contents/plugins'
       header = 'Accept: application/vnd.github.v3.raw'
+      token = git_config_reader.github_token
+      user = git_config_reader.github_user
 
       Dir.mkdir(plugins_dir) unless File.exists?(plugins_dir)
 
-      all_plugins = JSON.parse(`curl -s -H "#{header}" -L "#{plugins_url}"`)
+      all_plugins = JSON.parse(`curl -s -u #{user}:#{token} -H "#{header}" -L "#{plugins_url}"`)
 
       all_plugins.each do |plugin|
-        plugin_content = `curl -s -H "#{header}" -L "#{plugins_url}/#{plugin['name']}"`
+        plugin_content = `curl -s -u #{user}:#{token} -H "#{header}" -L "#{plugins_url}/#{plugin['name']}"`
         File.open("#{plugins_dir}/#{plugin['name']}", 'w') { |file| file.puts plugin_content }
       end
+    end
+
+    private def git_config_reader
+      @git_config_reader ||= GitHelper::GitConfigReader.new
     end
   end
 end

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,3 +1,3 @@
 module GitHelper
-  VERSION = '3.3.0'
+  VERSION = '3.3.1'
 end

--- a/spec/git_helper/git_config_reader_spec.rb
+++ b/spec/git_helper/git_config_reader_spec.rb
@@ -2,14 +2,16 @@ require 'spec_helper'
 require 'git_helper'
 
 describe GitHelper::GitConfigReader do
+  let(:github_user) { Faker::Internet.username }
   let(:github_token) { Faker::Internet.password(max_length: 10) }
+  let(:gitlab_user) { Faker::Internet.username }
   let(:gitlab_token) { Faker::Internet.password(max_length: 10) }
 
   let(:config_file) {
     {
-      github_user: Faker::Internet.username,
+      github_user: github_user,
       github_token: github_token,
-      gitlab_user: Faker::Internet.username,
+      gitlab_user: gitlab_user,
       gitlab_token: gitlab_token
     }
   }
@@ -37,6 +39,30 @@ describe GitHelper::GitConfigReader do
     it 'should call the config file' do
       expect(subject).to receive(:config_file).and_return(config_file)
       subject.github_token
+    end
+  end
+
+  describe '#github_user' do
+    it 'should locate the github_user' do
+      expect(subject).to receive(:config_file).and_return(config_file)
+      expect(subject.github_user).to eq(github_user)
+    end
+
+    it 'should call the config file' do
+      expect(subject).to receive(:config_file).and_return(config_file)
+      subject.github_user
+    end
+  end
+
+  describe '#gitlab_user' do
+    it 'should locate the gitlab_user' do
+      expect(subject).to receive(:config_file).and_return(config_file)
+      expect(subject.gitlab_user).to eq(gitlab_user)
+    end
+
+    it 'should call the config file' do
+      expect(subject).to receive(:config_file).and_return(config_file)
+      subject.gitlab_user
     end
   end
 

--- a/spec/git_helper/setup_spec.rb
+++ b/spec/git_helper/setup_spec.rb
@@ -133,6 +133,11 @@ describe GitHelper::Setup do
       ]"
     end
 
+    before do
+      allow_any_instance_of(GitHelper::GitConfigReader).to receive(:github_token).and_return(Faker::Internet.password)
+      allow_any_instance_of(GitHelper::GitConfigReader).to receive(:github_user).and_return(Faker::Internet.username)
+    end
+
     it 'should create the directory if it does not exist' do
       allow(File).to receive(:exists?).and_return(false)
       allow(File).to receive(:open).and_return(nil)


### PR DESCRIPTION
## Changes

When curling to get all of the plugin files, make sure we authenticate with the API so that we don't run out of API requests. Apparently unauthenticated requests are rate limited after 60, but authenticated requests go up to 5000. So authenticate. If a user doesn't have an API token.... then I guess they can do the plugin setup process manually (instructions for that are still in the readme).

## Related Pull Requests and Issues

* This was a bug released in https://github.com/emmahsax/git_helper/pull/47

## Additional Context

> Add any other context about the problem here.
