### PR TITLE
Require highline wrapper v1

### DIFF
--- a/git_helper.gemspec
+++ b/git_helper.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'gitlab', '~> 4.16'
   gem.add_dependency 'gli', '~> 2.13'
-  gem.add_dependency 'highline_wrapper', '~> 0.1.0'
+  gem.add_dependency 'highline_wrapper', '~> 1.0'
   gem.add_dependency 'octokit', '~> 4.18'
 
   gem.add_development_dependency 'bundler', '~> 2.2'

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHelper
-  VERSION = '3.3.4'
+  VERSION = '3.3.5'
 end


### PR DESCRIPTION
## Changes

Apparently in https://github.com/emmahsax/git_helper/pull/52, I forgot to actually bump the required version of `highline_wrapper` in the gemspec file.

## Related Pull Requests and Issues

* https://github.com/emmahsax/git_helper/pull/52

## Additional Context

> Add any other context about the problem here.
