### PR TITLE
Lock down psych gem

### DIFF
--- a/git_helper.gemspec
+++ b/git_helper.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'gli', '~> 2.13'
   gem.add_dependency 'highline_wrapper', '~> 1.1'
   gem.add_dependency 'octokit', '~> 4.18'
+  gem.add_dependency 'psych', '< 4'
 
   gem.add_development_dependency 'bundler', '~> 2.2'
   gem.add_development_dependency 'faker', '~> 2.15'

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHelper
-  VERSION = '3.3.6'
+  VERSION = '3.3.7'
 end


### PR DESCRIPTION
## Changes

Because of breaking changes that were released in `psych` 4.0.0, we need to lock down `psych`. More is explained here: https://github.com/ruby/psych/issues/490.

## Related Pull Requests and Issues

* https://github.com/ruby/psych/issues/490

## Additional Context

N/A
