### PR TITLE
Remove unnecessary gem dependency

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -2,6 +2,6 @@
 
 guard :rspec, cmd: 'bundle exec rspec', all_on_start: true do
   watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { 'spec' }
 end

--- a/git_helper.gemspec
+++ b/git_helper.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.name                  = 'git_helper'
   gem.version               = GitHelper::VERSION
   gem.authors               = ['Emma Sax']
-  gem.summary               = 'A set of GitHub and GitLab workflow scripts.'
+  gem.summary               = 'A set of GitHub and GitLab workflow scripts'
   gem.description           = 'A set of GitHub and GitLab workflow scripts to provide a smoother development ' \
                               'process for your git projects.'
   gem.homepage              = 'https://github.com/emmahsax/git_helper'
@@ -30,7 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'faker', '~> 2.15'
   gem.add_development_dependency 'guard-rspec', '~> 4.3'
   gem.add_development_dependency 'pry', '~> 0.13'
-  gem.add_development_dependency 'rake', '~> 13.0'
   gem.add_development_dependency 'rspec', '~> 3.9'
   gem.add_development_dependency 'rubocop', '~> 1.10'
 end

--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -33,7 +33,7 @@ module GitHelper
 
       create_or_update_plugin_files
       puts "\nNow add this line to your ~/.bash_profile:\n" \
-            '  export PATH=/path/to/computer/home/.git_helper/plugins:$PATH'
+           '  export PATH=/path/to/computer/home/.git_helper/plugins:$PATH'
       puts "\nDone!"
     end
 
@@ -49,6 +49,7 @@ module GitHelper
     end
 
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Layout/LineEndStringConcatenationIndentation
     private def generate_file_contents
       file_contents = ''.dup
 
@@ -75,6 +76,7 @@ module GitHelper
       file_contents.strip
     end
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Layout/LineEndStringConcatenationIndentation
 
     private def ask_question(prompt, secret: false)
       highline.ask(prompt, { required: true, secret: secret })

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHelper
-  VERSION = '3.4.1'
+  VERSION = '3.5.0'
 end


### PR DESCRIPTION
## Changes

* Remove the `rake` development dependency because it's not really required
* Correctly watch the `lib` files when using Guard
* Pass Rubocop again
* Update the gem's description and summary

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
