### PR TITLE
Update requirements on gems

### DIFF
--- a/git_helper.gemspec
+++ b/git_helper.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir['spec/spec_helper.rb'] + Dir['spec/git_helper/*.rb']
   gem.require_paths = ['lib']
 
+  gem.add_dependency 'faraday', '< 1.7.1'
   gem.add_dependency 'gitlab', '~> 4.16'
   gem.add_dependency 'gli', '~> 2.13'
   gem.add_dependency 'highline_wrapper', '~> 1.1'

--- a/git_helper.gemspec
+++ b/git_helper.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'gli', '~> 2.13'
   gem.add_dependency 'highline_wrapper', '~> 1.1'
   gem.add_dependency 'octokit', '~> 4.18'
-  gem.add_dependency 'psych', '< 4'
 
   gem.add_development_dependency 'bundler', '~> 2.2'
   gem.add_development_dependency 'faker', '~> 2.15'

--- a/git_helper.gemspec
+++ b/git_helper.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir['spec/spec_helper.rb'] + Dir['spec/git_helper/*.rb']
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'faraday', '< 1.7.1'
   gem.add_dependency 'gitlab', '~> 4.16'
   gem.add_dependency 'gli', '~> 2.13'
   gem.add_dependency 'highline_wrapper', '~> 1.1'

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHelper
-  VERSION = '3.5.0'
+  VERSION = '3.5.1-test'
 end

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHelper
-  VERSION = '3.5.1-test'
+  VERSION = '3.5.2'
 end

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHelper
-  VERSION = '3.5.2'
+  VERSION = '3.5.1'
 end


### PR DESCRIPTION
## Changes

#### Psych

Now that psych version 4.0.1 has been released, I'm going to trial removing the upper dependency on the psych gem. Perhaps upgrading my machine to 4.0.1 will not result in errors. Previously, I had issues making merge requests (on GitLab) and pull requests (on GitHub), so it seems to be doing better so far. My guess is that git_helper will still not be compatible with psych 4.0.0, so it's now up to each user of git_helper to update their local psych verison.

#### Faraday

Faraday released version 1.7.1, which ends up resulting in warning messages. We need to wait for 1.7.2 to be released in order to address those. See more [here](https://github.com/octokit/octokit.rb/issues/1357). Although this is something new that I'm finding now, I don't see the value in waiting to release a new version of this gem. When Octokit updates their versions, then each user of git_helper can locally pull a new Faraday version.

```
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

## Related Pull Requests and Issues

* https://github.com/emmahsax/git_helper/pull/56
* https://github.com/octokit/octokit.rb/issues/1357

## Additional Context

> Add any other context about the problem here.
