### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -14,6 +14,7 @@ env:
   GITLEAKS_CONFIG_COMMITS: "[]" # A list of commits to ignore when running GitLeaks
   GITLEAKS_CONFIG_REGEXES: "[]" # A list of regexes or secrets to ignore when running GitLeaks
   GITLEAKS_CONFIG_PATHS: "[]" # A list of file paths to ignore when running GitLeaks
+  RUN_DEFAULT_ON_ALL_COMMITS: 'true' # Whether to run GitLeaks from default branch on all git history, or since a certain commit specified below
 
 ###########################################################
 ### DO NOT EDIT BELOW – TEXT IS AUTOMATICALLY GENERATED ###
@@ -37,16 +38,24 @@ jobs:
           echo "commits = ${{ env.GITLEAKS_CONFIG_COMMITS }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
           echo "regexes = ${{ env.GITLEAKS_CONFIG_REGEXES }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
           echo "paths = ${{ env.GITLEAKS_CONFIG_PATHS }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
-      - name: GitLeaks
+      - name: Determine GitLeaks Command
         run: |
           DEFAULT_BRANCH_COMMIT=$(git log origin/main | head -1 | sed 's/commit //')
           COMMAND="gitleaks detect --verbose --config='/app/gitleaks.toml' --source='/app'"
           if [[ ${{ github.REF }} == 'refs/heads'* ]]; then # This is a branch, not a pull request
-            if [[ ${{ github.SHA }} != $DEFAULT_BRANCH_COMMIT ]]; then # This branch IS the default branch
-              COMMAND="${COMMAND} --log-opts='^origin/main ${{ github.SHA }}'"
+            if [[ ${{ github.SHA }} != $DEFAULT_BRANCH_COMMIT ]]; then # This branch is not the default branch
+              echo "COMMAND=\"${COMMAND} --log-opts='^origin/main ${{ github.SHA }}'\"" >> $GITHUB_ENV
+            else
+              if [[ ${{ env.RUN_DEFAULT_ON_ALL_COMMITS }} == 'false' ]]; then
+                echo "COMMAND=\"${COMMAND} --log-opts='${{ env.RUN_DEFAULT_ON_SINCE_COMMIT }}..${{ github.SHA }}'\"" >> $GITHUB_ENV
+              else
+                echo "COMMAND=\"${COMMAND}\"" >> $GITHUB_ENV
+              fi
             fi
           else
-            COMMAND="${COMMAND} --log-opts='^origin/main ${{ github.EVENT.PULL_REQUEST.HEAD.SHA }}'"
+            echo "COMMAND=\"${COMMAND} --log-opts='^origin/main ${{ github.EVENT.PULL_REQUEST.HEAD.SHA }}'\"" >> $GITHUB_ENV
           fi
-          echo "Running: $COMMAND"
-          docker run --rm -v $(pwd):/app -i --entrypoint /bin/bash zricethezav/gitleaks:${{ env.GITLEAKS_VERSION }} -c "$COMMAND"
+      - name: GitLeaks
+        run: |
+          echo "Running: ${{ env.COMMAND }}"
+          docker run --rm -v $(pwd):/app -i --entrypoint /bin/bash zricethezav/gitleaks:${{ env.GITLEAKS_VERSION }} -c ${{ env.COMMAND }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -46,10 +46,10 @@ jobs:
             if [[ ${{ github.SHA }} != $DEFAULT_BRANCH_COMMIT ]]; then # This branch is not the default branch
               echo "COMMAND=\"${COMMAND} --log-opts='^origin/main ${{ github.SHA }}'\"" >> $GITHUB_ENV
             else
-              if [[ ${{ env.RUN_DEFAULT_ON_ALL_COMMITS }} == 'false' ]]; then
-                echo "COMMAND=\"${COMMAND} --log-opts='${{ env.RUN_DEFAULT_ON_SINCE_COMMIT }}..${{ github.SHA }}'\"" >> $GITHUB_ENV
-              else
+              if [[ ${{ env.RUN_DEFAULT_ON_ALL_COMMITS }} == 'true' ]]; then # Running on all commits in git history
                 echo "COMMAND=\"${COMMAND}\"" >> $GITHUB_ENV
+              else
+                echo "COMMAND=\"${COMMAND} --log-opts='${{ env.RUN_DEFAULT_ON_SINCE_COMMIT }}..${{ github.SHA }}'\"" >> $GITHUB_ENV
               fi
             fi
           else

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,40 +9,44 @@ on:
 
 # Override environment variables as needed
 env:
+  GITLEAKS_VERSION: v8.0.4
+  GITLEAKS_REF: f15b4e408b12fda7e2833f8a32c0d8a045bd48a0
   GITLEAKS_CONFIG_COMMITS: "[]" # A list of commits to ignore when running GitLeaks
   GITLEAKS_CONFIG_REGEXES: "[]" # A list of regexes or secrets to ignore when running GitLeaks
+  GITLEAKS_CONFIG_PATHS: "[]" # A list of file paths to ignore when running GitLeaks
 
 ###########################################################
 ### DO NOT EDIT BELOW – TEXT IS AUTOMATICALLY GENERATED ###
 ###########################################################
 
 jobs:
-  default:
+  gitleaks:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set GitLeaks Config
+      - name: Set GitLeaks Config File
         run: |
-          if [[ ${{ github.REF }} == 'refs/heads'* ]]; then # This is a branch, not a pull request
-            CURRENT_COMMIT="${{ github.SHA }}"
-          else
-            CURRENT_COMMIT="${{ github.EVENT.PULL_REQUEST.HEAD.SHA }}"
-          fi
-          echo "COMMITS=$(
-            git rev-list $CURRENT_COMMIT ^origin/main | sed 's/^\|$//g' | paste -sd, -
-          )" >> $GITHUB_ENV
-          echo "Title = 'GitLeaks Allowlist'" >> ${{ github.WORKSPACE }}/gitleaks.toml
+          curl -H "Accept: application/vnd.github.v3.raw" \
+            -L "https://api.github.com/repos/zricethezav/gitleaks/contents/config/gitleaks.toml?ref=${{ env.GITLEAKS_REF }}" \
+            >> ${{ github.WORKSPACE }}/original.toml
+          sed "/\[allowlist\]/,/^$/d" ${{ github.WORKSPACE }}/original.toml >> ${{ github.WORKSPACE }}/gitleaks.toml
           echo "[allowlist]" >> ${{ github.WORKSPACE }}/gitleaks.toml
-          echo "  commits = ${{ env.GITLEAKS_CONFIG_COMMITS }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
-          echo "  regexes = ${{ env.GITLEAKS_CONFIG_REGEXES }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
+          echo "commits = ${{ env.GITLEAKS_CONFIG_COMMITS }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
+          echo "regexes = ${{ env.GITLEAKS_CONFIG_REGEXES }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
+          echo "paths = ${{ env.GITLEAKS_CONFIG_PATHS }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
       - name: GitLeaks
         run: |
-          COMMAND="gitleaks --verbose --additional-config='/app/gitleaks.toml' --path='/app'"
-          if [ ${{ github.REF }} != 'refs/heads/main' ]; then
-            COMMAND="${COMMAND} --commits='${{ env.COMMITS }}'"
+          DEFAULT_BRANCH_COMMIT=$(git log origin/main | head -1 | sed 's/commit //')
+          COMMAND="gitleaks detect --verbose --config='/app/gitleaks.toml' --source='/app'"
+          if [[ ${{ github.REF }} == 'refs/heads'* ]]; then # This is a branch, not a pull request
+            if [[ ${{ github.SHA }} != $DEFAULT_BRANCH_COMMIT ]]; then # This branch IS the default branch
+              COMMAND="${COMMAND} --log-opts='^origin/main ${{ github.SHA }}'"
+            fi
+          else
+            COMMAND="${COMMAND} --log-opts='^origin/main ${{ github.EVENT.PULL_REQUEST.HEAD.SHA }}'"
           fi
-          docker pull zricethezav/gitleaks
-          docker run --rm -v $(pwd):/app -i --entrypoint /bin/bash zricethezav/gitleaks -c "$COMMAND"
+          echo "Running: $COMMAND"
+          docker run --rm -v $(pwd):/app -i --entrypoint /bin/bash zricethezav/gitleaks:${{ env.GITLEAKS_VERSION }} -c "$COMMAND"

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,7 +12,7 @@ on:
 ###########################################################
 
 jobs:
-  default:
+  rspec:
     runs-on: ubuntu-latest
     steps:
       - name: Set Branch Variable

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,7 +10,7 @@ on:
 ###########################################################
 
 jobs:
-  default:
+  rubocop:
     runs-on: ubuntu-latest
     steps:
       - name: Set Branch Variable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,9 @@ Style/MixinUsage:
 Style/NegatedIfElseCondition:
   Enabled: true
 
+Style/OpenStructUse:
+  Enabled: false
+
 Style/OptionalBooleanParameter:
   Enabled: true
   # AllowedMethods: method_missing

--- a/git_helper.gemspec
+++ b/git_helper.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage              = 'https://github.com/emmahsax/git_helper'
   gem.license               = 'BSD-3-Clause'
   gem.required_ruby_version = '>= 2.5'
+  gem.metadata              = { 'rubygems_mfa_required' => 'true' }
 
   gem.executables   = Dir['bin/*'].map { |f| File.basename(f) }
   gem.files         = Dir['lib/git_helper/*.rb'] + Dir['lib/*.rb'] + Dir['bin/*']

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHelper
-  VERSION = '3.6.0'
+  VERSION = '3.6.1'
 end


### PR DESCRIPTION
## Changes

This PR updates the following:
* Change the names of the jobs on GitHub Actions workflows
* Updates the GitLeaks Github Action to use GitLeaks v8.0.4
* Require MFA when pushing this gem to RubyGems
* Update the gem version
* Disable the new Rubocop cop `Style/OpenStructUse`, as we still want to use OpenStruct in this project (if we decide we want to switch to something new later, we can make a change later)

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
