### PR TITLE
Support higher version of faker in development

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,7 +13,7 @@ env:
     'QPHNXYfNwA1m1LTF7c8xY8pfj5t13vzb0GkA3ZoU',
     'tEBvYBpZi4OIRtS43mLpjLdR6Sp14xSbMZgBgNsv'
   ]"
-  GITLEAKS_VERSION: v8.8.7
+  GITLEAKS_VERSION: v8.15.0
   RUN_DEFAULT_ON_ALL_COMMITS: 'true'
 
 ###########################################################

--- a/git_helper.gemspec
+++ b/git_helper.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'highline_wrapper', '~> 1.1'
 
   gem.add_development_dependency 'bundler', '~> 2.2'
-  gem.add_development_dependency 'faker', '~> 2.15'
+  gem.add_development_dependency 'faker', '~> 3.0'
   gem.add_development_dependency 'guard-rspec', '~> 4.3'
   gem.add_development_dependency 'pry', '~> 0.13'
   gem.add_development_dependency 'rspec', '~> 3.9'

--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -32,7 +32,7 @@ module GitHelper
       return unless answer
 
       create_or_update_plugin_files
-      puts "\nNow add this line to your ~/.bash_profile:\n " \
+      puts "\nNow add this line to your ~/.bash_profile:\n  " \
            'export PATH=/path/to/computer/home/.git_helper/plugins:$PATH'
       puts "\nDone!"
     end

--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -88,7 +88,7 @@ module GitHelper
       token = git_config_reader.github_token
       user = git_config_reader.github_user
 
-      Dir.mkdir(plugins_dir)
+      FileUtils.mkdir_p(plugins_dir)
 
       all_plugins = JSON.parse(`curl -s -u #{user}:#{token} -H "#{header}" -L "#{plugins_url}"`)
 

--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -98,6 +98,7 @@ module GitHelper
       end
     end
     # rubocop:enable Metrics/MethodLength
+
     private def config_file
       git_config_reader.git_config_file_path
     end

--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -32,8 +32,8 @@ module GitHelper
       return unless answer
 
       create_or_update_plugin_files
-      puts "\nNow add this line to your ~/.bash_profile:\n" \
-           '  export PATH=/path/to/computer/home/.git_helper/plugins:$PATH'
+      puts "\nNow add this line to your ~/.bash_profile:\n " \
+           'export PATH=/path/to/computer/home/.git_helper/plugins:$PATH'
       puts "\nDone!"
     end
 
@@ -66,8 +66,8 @@ module GitHelper
         file_contents << ":gitlab_user:  #{ask_question('GitLab username?')}\n"
         file_contents << ':gitlab_token: ' \
           "#{ask_question(
-            'GitLab personal access token? (Navigate to https://gitlab.com/-/profile/personal_access_tokens' \
-            ' to create a new personal access token)',
+            'GitLab personal access token? (Navigate to https://gitlab.com/-/profile/personal_access_tokens ' \
+            'to create a new personal access token)',
             secret: true
           )}\n"
       end
@@ -81,7 +81,6 @@ module GitHelper
     end
 
     # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     private def create_or_update_plugin_files
       plugins_dir = "#{Dir.pwd.scan(%r{\A/\w*/\w*/}).first}.git_helper/plugins"
       plugins_url = 'https://api.github.com/repos/emmahsax/git_helper/contents/plugins'
@@ -89,7 +88,7 @@ module GitHelper
       token = git_config_reader.github_token
       user = git_config_reader.github_user
 
-      Dir.mkdir(plugins_dir) unless File.exist?(plugins_dir)
+      Dir.mkdir(plugins_dir)
 
       all_plugins = JSON.parse(`curl -s -u #{user}:#{token} -H "#{header}" -L "#{plugins_url}"`)
 
@@ -99,8 +98,6 @@ module GitHelper
       end
     end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
-
     private def config_file
       git_config_reader.git_config_file_path
     end

--- a/spec/git_helper/setup_spec.rb
+++ b/spec/git_helper/setup_spec.rb
@@ -147,7 +147,7 @@ describe GitHelper::Setup do
     it 'should create the directory if it does not exist' do
       allow(File).to receive(:exist?).and_return(false)
       allow(File).to receive(:open).and_return(nil)
-      expect(Dir).to receive(:mkdir)
+      expect(FileUtils).to receive(:mkdir_p)
       allow(subject).to receive(:`).and_return(plugins_json)
       allow(JSON).to receive(:parse).and_return(plugins)
       subject.send(:create_or_update_plugin_files)

--- a/spec/git_helper/setup_spec.rb
+++ b/spec/git_helper/setup_spec.rb
@@ -153,15 +153,6 @@ describe GitHelper::Setup do
       subject.send(:create_or_update_plugin_files)
     end
 
-    it 'should not create the directory if it already exists' do
-      allow(File).to receive(:exist?).and_return(true)
-      allow(File).to receive(:open).and_return(nil)
-      expect(Dir).not_to receive(:mkdir)
-      allow(subject).to receive(:`).and_return(plugins_json)
-      allow(JSON).to receive(:parse).and_return(plugins)
-      subject.send(:create_or_update_plugin_files)
-    end
-
     it 'should curl the GitHub API' do
       allow(Dir).to receive(:mkdir).and_return(true)
       allow(File).to receive(:exists?).and_return(true)


### PR DESCRIPTION
## Changes

* Support a higher level of the `faker` gem in development mode
* Update GitLeaks to the newest patch version in development
* Address complaints from Rubocop
* When creating a `~/.git_helper` directory during the `setup` command, attempt to make the directory no matter what, and don't fail if the directory already exists. Before this change, the code would see if it exists before making the directory, which worked, but added a tiny bit of complexity.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
