### PR TITLE
Fix bug where git_helper didn't output new merge request URL

### DIFF
--- a/lib/git_helper/merge_request.rb
+++ b/lib/git_helper/merge_request.rb
@@ -29,12 +29,12 @@ module GitHelper
       puts "Creating merge request: #{new_mr_title}"
       mr = gitlab_client.create_merge_request(local_project, options)
 
-      if !mr.diff_refs.nil? && mr.web_url && (mr.diff_refs['base_sha'] == mr.diff_refs['head_sha'])
+      if mr.web_url && mr.diff_refs && (mr.diff_refs['base_sha'] == mr.diff_refs['head_sha'])
         puts "Merge request was created, but no commits have been pushed to GitLab: #{mr.web_url}"
       elsif mr.web_url
         puts "Merge request successfully created: #{mr.web_url}"
       else
-        raise StandardError, (mr.message.class == Array ? mr.message.first : mr.message)
+        raise StandardError, (mr.message.instance_of?(Array) ? mr.message.first : mr.message)
       end
     rescue StandardError => e
       puts 'Could not create merge request:'

--- a/lib/git_helper/merge_request.rb
+++ b/lib/git_helper/merge_request.rb
@@ -29,21 +29,16 @@ module GitHelper
       puts "Creating merge request: #{new_mr_title}"
       mr = gitlab_client.create_merge_request(local_project, options)
 
-      raise StandardError, mr.message if mr.diff_refs.nil? || mr.web_url.nil?
-
-      if mr.diff_refs['base_sha'] == mr.diff_refs['head_sha']
+      if !mr.diff_refs.nil? && mr.web_url && (mr.diff_refs['base_sha'] == mr.diff_refs['head_sha'])
         puts "Merge request was created, but no commits have been pushed to GitLab: #{mr.web_url}"
-      else
+      elsif mr.web_url
         puts "Merge request successfully created: #{mr.web_url}"
+      else
+        raise StandardError, (mr.message.class == Array ? mr.message.first : mr.message)
       end
     rescue StandardError => e
       puts 'Could not create merge request:'
-
-      if e.message.include?('Another open merge request already exists')
-        puts '  A merge request already exists for this branch'
-      else
-        puts "  #{e.message}"
-      end
+      puts "  #{e.message}"
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHelper
-  VERSION = '3.6.1'
+  VERSION = '3.6.2'
 end

--- a/spec/git_helper/merge_request_spec.rb
+++ b/spec/git_helper/merge_request_spec.rb
@@ -56,6 +56,24 @@ describe GitHelper::GitLabMergeRequest do
       allow(gitlab_client).to receive(:create_merge_request).and_raise(StandardError)
       expect(subject.create({ base_branch: Faker::Lorem.word, new_title: Faker::Lorem.word })).to eq(nil)
     end
+
+    context 'when diff_refs is nil' do
+      let(:merge_request) do
+        double(:merge_request,
+               message: Faker::Lorem.sentence,
+               diff_refs: nil,
+               web_url: Faker::Internet.url,
+               merge_commit_sha: Faker::Internet.password)
+      end
+
+      it 'should continue if diff_refs is nil' do
+        allow(subject).to receive(:squash_merge_request).and_return(true)
+        allow(subject).to receive(:remove_source_branch).and_return(false)
+        allow(subject).to receive(:new_mr_body).and_return('')
+        allow(gitlab_client).to receive(:create_merge_request)
+        expect { subject.create({ base_branch: Faker::Lorem.word, new_title: Faker::Lorem.word }) }.not_to raise_error
+      end
+    end
   end
 
   describe '#merge' do


### PR DESCRIPTION
## Changes

There's a current bug (probably with the GitLab API) which results in the `diff_refs` showing up as `nil`, even when it shouldn't be. This results in the following error when creating new merge requests:
```
$ git code-request
Is 'main' the correct base branch for your new code request? (y/n)
--- Default selected: YES ---
Accept the autogenerated code request title 'Test1'? (y/n)
--- Default selected: YES ---
Apply the merge request template from .gitlab/merge_request_template.md? (y/n)
--- Default selected: YES ---
Creating merge request: Test1
Could not create merge request:
  StandardError
```

 Doing some debugging shows me that the `diff_refs` is returning `nil` when it shouldn't. So, a simple change is to allow `diff_refs` to be `nil` before throwing a `StandardError` (previously line 32). As long as the `web_url` is present, that indicates from the API that there's a new merge request to show. Unfortunately, without the `diff_refs` there at all, there's not a good way for git_helper to determine when there are no new commits pushed. So for the time being, until they fix their bug, git_helper will not indicate that there's no commits pushed to the merge request when it is supposed to.

Hopefully GitLab will fix their bug, and then the preexisting functionality of this command will come back.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
