### PR TITLE
Make plugins executable

### DIFF
--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -91,7 +91,7 @@ module GitHelper
 
       all_plugins.each do |plugin|
         plugin_content = `curl -s -H "#{header}" -L "#{plugins_url}/#{plugin['name']}"`
-        File.open("#{plugins_dir}/#{plugin['name']}", 'w', 0755) { |file| file.puts plugin_content }
+        File.open("#{plugins_dir}/#{plugin['name']}", 'w', 0o755) { |file| file.puts plugin_content }
       end
     end
 

--- a/lib/git_helper/setup.rb
+++ b/lib/git_helper/setup.rb
@@ -91,7 +91,7 @@ module GitHelper
 
       all_plugins.each do |plugin|
         plugin_content = `curl -s -H "#{header}" -L "#{plugins_url}/#{plugin['name']}"`
-        File.open("#{plugins_dir}/#{plugin['name']}", 'w') { |file| file.puts plugin_content }
+        File.open("#{plugins_dir}/#{plugin['name']}", 'w', 0755) { |file| file.puts plugin_content }
       end
     end
 

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHelper
-  VERSION = '3.6.4'
+  VERSION = '3.6.5'
 end


### PR DESCRIPTION
## Changes

> A list of the changes that your pull request will make:
>
> * Adding a page "..."
> * Refactoring "..."

When creating plugins, all plugin files need to be fully executable (permissions `0755`) on the system. Currently, the `git-helper setup` command just creates the files. Now with this change, we automatically set them all to `0755` as well.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
